### PR TITLE
Add combinators for dealing with decode failures

### DIFF
--- a/lib/Data/Aeson/Combinators/Decode.hs
+++ b/lib/Data/Aeson/Combinators/Decode.hs
@@ -99,6 +99,7 @@ import           Data.Aeson.Types
 import qualified Data.ByteString            as B
 import qualified Data.ByteString.Lazy       as LB
 import           Data.Int                   (Int16, Int32, Int64, Int8)
+import           Data.List.NonEmpty         (NonEmpty(..))
 import           Data.Text                  (Text)
 import           Data.Time.Calendar         (Day)
 #if (MIN_VERSION_time_compat(1,9,2))
@@ -652,10 +653,9 @@ either (Decoder d) =
 -- > Just (Right False)
 -- > >>> decode (oneOf [Right <$> bool, return (Left "Not a boolean")]) "42"
 -- > Just (Left "Not a boolean")
-oneOf :: [Decoder a] -> Decoder a
-oneOf [] = Fail.fail "No decoders provided."
-oneOf decoders =
-  foldr1 (<|>) decoders
+oneOf :: NonEmpty (Decoder a) -> Decoder a
+oneOf (first :| rest) =
+  foldr (<|>) first rest
 {-# INLINE oneOf #-}
 
 -- Decoding

--- a/lib/Data/Aeson/Combinators/Decode.hs
+++ b/lib/Data/Aeson/Combinators/Decode.hs
@@ -622,8 +622,8 @@ jsonMaybe :: Decoder a -> Decoder (Maybe a)
 jsonMaybe (Decoder d) =
   Decoder $ \val ->
     case parse d val of
-      Success x -> return (Just x)
-      Error _ -> return Nothing
+      Success x -> pure (Just x)
+      Error _ -> pure Nothing
 {-# INLINE jsonMaybe #-}
 
 -- | Try a decoder and get back a 'Right a' if it succeeds and a 'Left String' if it fails.
@@ -637,8 +637,8 @@ jsonEither :: Decoder a -> Decoder (Either String a)
 jsonEither (Decoder d) =
   Decoder $ \val ->
     case parse d val of
-      Success x -> return (Right x)
-      Error err -> return (Left err)
+      Success x -> pure (Right x)
+      Error err -> pure (Left err)
 {-# INLINE jsonEither #-}
 
 -- | Try a number of decoders in order and return the first success.

--- a/lib/Data/Aeson/Combinators/Decode.hs
+++ b/lib/Data/Aeson/Combinators/Decode.hs
@@ -72,8 +72,8 @@ module Data.Aeson.Combinators.Decode (
   , element
   , path
 -- *** Dealing With Failure
-  , jsonMaybe
-  , jsonEither
+  , maybe
+  , either
   , oneOf
 -- * Running Decoders
 -- $running
@@ -122,7 +122,8 @@ import qualified Data.Map.Lazy              as ML
 import qualified Data.Map.Strict            as MS
 import           Data.Scientific            (Scientific)
 import           Data.Traversable           (traverse)
-import           Prelude                    hiding (fail)
+import qualified Prelude                    (either)
+import           Prelude                    hiding (fail, maybe, either)
 
 -- $usage
 -- As mentioned above, combinators and type classes can be used together.
@@ -614,32 +615,32 @@ path pth d = foldr element d pth
 -- | Try a decoder and get back a 'Just a' if it succeeds and 'Nothing' if it fails.
 -- In other words, this decoder always succeeds with a 'Maybe a' value.
 --
--- > >>> decode (jsonMaybe string) "42"
+-- > >>> decode (maybe string) "42"
 -- > Just Nothing
--- > >>> decode (jsonMaybe int) "42"
+-- > >>> decode (maybe int) "42"
 -- > Just (Just 42)
-jsonMaybe :: Decoder a -> Decoder (Maybe a)
-jsonMaybe (Decoder d) =
+maybe :: Decoder a -> Decoder (Maybe a)
+maybe (Decoder d) =
   Decoder $ \val ->
     case parse d val of
       Success x -> pure (Just x)
       Error _ -> pure Nothing
-{-# INLINE jsonMaybe #-}
+{-# INLINE maybe #-}
 
 -- | Try a decoder and get back a 'Right a' if it succeeds and a 'Left String' if it fails.
 -- In other words, this decoder always succeeds with an 'Either String a' value.
 --
--- > >>> decode (jsonEither string) "42"
+-- > >>> decode (either string) "42"
 -- > Just (Left "expected String, but encountered Number")
--- > >>> decode (jsonEither int) "42"
+-- > >>> decode (either int) "42"
 -- > Just (Right 42)
-jsonEither :: Decoder a -> Decoder (Either String a)
-jsonEither (Decoder d) =
+either :: Decoder a -> Decoder (Either String a)
+either (Decoder d) =
   Decoder $ \val ->
     case parse d val of
       Success x -> pure (Right x)
       Error err -> pure (Left err)
-{-# INLINE jsonEither #-}
+{-# INLINE either #-}
 
 -- | Try a number of decoders in order and return the first success.
 --
@@ -797,7 +798,7 @@ eitherDecodeFileStrict' dec =
 -- Private functions Aeson doesn't expose
 
 eitherFormatError :: Either (JSONPath, String) a -> Either String a
-eitherFormatError = either (Left . uncurry AI.formatError) Right
+eitherFormatError = Prelude.either (Left . uncurry AI.formatError) Right
 {-# INLINE eitherFormatError #-}
 
 #if (MIN_VERSION_aeson(1,4,3))


### PR DESCRIPTION
First off, thank you for providing this library! I dislike how Aeson couples a single specific decoding technique to its result type, and I really like the way Elm implemented its Json.Decode module. Having this in Haskell is a big improvement!

This pull request would add `jsonMaybe` and `jsonEither` which each produce a new decoder that tries the provided decoder and succeeds with `Just a` or `Right a` respectively or, in the case of failure, succeeds with `Nothing` or `Left String` respectively. As far as I can tell, these functions provide new functionality because without them there is no way to handle failure explicitly in a monadic context.

I've also defined the `oneOf` function which takes a list of decoders and tries them in order until one succeeds. This is implemented with the Alternative type class under the hood, but for developers coming from Elm (like me) who might not be familiar with the Alternative type class, having a `oneOf` function like the one in Elm's Json.Decode module would be nice.

Please let me know what you think!