### PR TITLE
Update stackage lts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
       - run: nix-build -A ghc902
 
-  ghc922:
+  ghc925:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
@@ -68,7 +68,7 @@ jobs:
         with:
           name: aeson-combinators
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-      - run: nix-build -A ghc922
+      - run: nix-build -A ghc925
 
   stack-aeson-2:
     runs-on: ubuntu-latest

--- a/aeson-combinators.cabal
+++ b/aeson-combinators.cabal
@@ -21,8 +21,7 @@ homepage:            https://github.com/turboMaCk/aeson-combinators
 tested-with:         GHC == 8.8.4
                    , GHC == 8.10.7
                    , GHC == 9.0.2
-                   , GHC == 9.2.1
-                   , GHC == 9.2.2
+                   , GHC == 9.2.5
                    , GHCJS == 8.6.0.1
 
 Flag doctest

--- a/default.nix
+++ b/default.nix
@@ -24,5 +24,5 @@ in with pkgs; {
   ghc884 = haskell.packages.ghc884.aeson-combinators;
   ghc8107 = haskell.packages.ghc8107.aeson-combinators;
   ghc902 = haskell.packages.ghc902.aeson-combinators;
-  ghc922 = haskell.packages.ghc922.aeson-combinators;
+  ghc925 = haskell.packages.ghc925.aeson-combinators;
 }

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: nightly-2022-05-03
+resolver: lts-20.8

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    sha256: 4d83e1d937d8c847b1011e6080997b314e011c8aa6cc3b161f94654c7bd51089
-    size: 554662
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2022/5/3.yaml
-  original: nightly-2022-05-03
+    sha256: bfafe5735ccb74527d754b1f9999ded72d7c3a6c3a88529449661431ccfbd6cc
+    size: 649327
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/8.yaml
+  original: lts-20.8


### PR DESCRIPTION
CI was failing in #33 because `ghc922` seems to not be available anymore in `haskellPackages`. Maybe it could be updated to the current stack resolver LTS (9.2.5).

I tried all the cabal targets with this versions and everything seems to be fine.